### PR TITLE
An empty `ZCASH_VERSION` (now default) installs latest `zcashd` release.

### DIFF
--- a/zcashd/Dockerfile
+++ b/zcashd/Dockerfile
@@ -4,14 +4,24 @@ RUN apt-get update \
   && apt-get install -y gnupg2 apt-transport-https curl
 
 ARG ZCASH_SIGNING_KEY_ID=6DEF3BAF272766C0
-ARG ZCASH_VERSION=2.0.7+2
+
+ARG ZCASH_VERSION=
+# The empty string for ZCASH_VERSION will install the apt default version,
+# which should be the latest stable release. To install a specific
+# version, pass `--build-arg 'ZCASH_VERSION=<version>'` to `docker build`.
+
 ARG ZCASHD_USER=zcashd
 ARG ZCASHD_UID=2001
 
 RUN apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys $ZCASH_SIGNING_KEY_ID \
   && echo "deb [arch=amd64] https://apt.z.cash/ jessie main" > /etc/apt/sources.list.d/zcash.list \
-  && apt-get update \
-  && apt-get install -y zcash=$ZCASH_VERSION
+  && apt-get update
+
+RUN if [ -z "$ZCASH_VERSION" ]; \
+    then apt-get install -y zcash; \
+    else apt-get install -y zcash=$ZCASH_VERSION; \
+    fi; \
+    zcashd --version
 
 RUN useradd --home-dir /srv/$ZCASHD_USER \
             --shell /bin/bash \


### PR DESCRIPTION
This alters `zcashd/Dockerfile` in two ways:

- If `ZCASH_VERSION` is the empty string, then install the default apt version (which should be the latest `zcashd` version). This results in running `apt-get install -y zcash`. Otherwise, install the version given in the `ZCASH_VERSION` arg. 
- Also, set `ZCASH_VERSION` to the empty string by default. This part may be dangerous if any ECC or Zcash infrastructure relies on the hard-coded version and doesn't expect "latest version" on builds.