### PR TITLE
Use exec for entrypoint when starting zcashd

### DIFF
--- a/zcashd/entrypoint.sh
+++ b/zcashd/entrypoint.sh
@@ -48,4 +48,4 @@ fi
 zcash-fetch-params
 touch .zcash/zcash.conf
 echo "Starting: ${ZCASHD_CMD}"
-${ZCASHD_CMD}
+exec ${ZCASHD_CMD}


### PR DESCRIPTION
This change allows signals from the docker deamon to be received by the zcashd process.

Previously, stop signals where intercepted by the entrypont script, so a container stop event was not getting to zcashd, and it was being terminated without getting a chance to clean up.

