### PR TITLE
Update zcashd entrypoint to take env for rpcport

### DIFF
--- a/zcashd/entrypoint.sh
+++ b/zcashd/entrypoint.sh
@@ -34,7 +34,7 @@ if [[ -n "${ZCASHD_ZSHIELDCOINBASE}" ]];then ZCASHD_CMD+=" -zshieldcoinbase=${ZC
 if [[ -n "${ZCASHD_RPCUSER}" ]];then ZCASHD_CMD+=" -rpcuser=${ZCASHD_RPCUSER}";fi
 if [[ -n "${ZCASHD_RPCPASSWORD}" ]];then ZCASHD_CMD+=" -rpcpassword=${ZCASHD_RPCPASSWORD}";fi
 if [[ -n "${ZCASHD_RPCBIND}" ]];then ZCASHD_CMD+=" -rpcbind=${ZCASHD_RPCBIND}";fi
-if [[ -n "${ZCASHD_RPCPORT}" ]];then ZCASHD_CMD+=" -rpcbind=${ZCASHD_RPCPORT}";fi
+if [[ -n "${ZCASHD_RPCPORT}" ]];then ZCASHD_CMD+=" -rpcport=${ZCASHD_RPCPORT}";fi
 if [[ -n "${ZCASHD_ALLOWIP}" ]];then ZCASHD_CMD+=" -rpcallowip=${ZCASHD_ALLOWIP}";fi
 if [[ -n "${ZCASHD_TXINDEX}" ]];then ZCASHD_CMD+=" -txindex";fi
 if [[ -n "${ZCASHD_INSIGHTEXPLORER}" ]];then ZCASHD_CMD+=" -insightexplorer";fi

--- a/zcashd/entrypoint.sh
+++ b/zcashd/entrypoint.sh
@@ -34,6 +34,7 @@ if [[ -n "${ZCASHD_ZSHIELDCOINBASE}" ]];then ZCASHD_CMD+=" -zshieldcoinbase=${ZC
 if [[ -n "${ZCASHD_RPCUSER}" ]];then ZCASHD_CMD+=" -rpcuser=${ZCASHD_RPCUSER}";fi
 if [[ -n "${ZCASHD_RPCPASSWORD}" ]];then ZCASHD_CMD+=" -rpcpassword=${ZCASHD_RPCPASSWORD}";fi
 if [[ -n "${ZCASHD_RPCBIND}" ]];then ZCASHD_CMD+=" -rpcbind=${ZCASHD_RPCBIND}";fi
+if [[ -n "${ZCASHD_RPCPORT}" ]];then ZCASHD_CMD+=" -rpcbind=${ZCASHD_RPCPORT}";fi
 if [[ -n "${ZCASHD_ALLOWIP}" ]];then ZCASHD_CMD+=" -rpcallowip=${ZCASHD_ALLOWIP}";fi
 if [[ -n "${ZCASHD_TXINDEX}" ]];then ZCASHD_CMD+=" -txindex";fi
 if [[ -n "${ZCASHD_INSIGHTEXPLORER}" ]];then ZCASHD_CMD+=" -insightexplorer";fi


### PR DESCRIPTION
While we could determine the rpc port dynamically based on the value of `ZCASHD_NETWORK`, the rpc port need to be shared to any rpc service consumers.

Adding it to an environment that can be shared ensure all containers use the same port and logic to derive the value.

