### PR TITLE
Pass any additional zcashd flags to the daemon

### DIFF
--- a/zcashd/entrypoint.sh
+++ b/zcashd/entrypoint.sh
@@ -48,4 +48,4 @@ fi
 zcash-fetch-params
 touch .zcash/zcash.conf
 echo "Starting: ${ZCASHD_CMD}"
-exec ${ZCASHD_CMD}
+exec "${ZCASHD_CMD}" "${@}"


### PR DESCRIPTION
Allow any additional command line flags to be passed to zcashd.

This allows for configurations not covered by the entrypoint.sh script.

