### PR TITLE
Updated zcash-insight-explorer entrypoint for ports and signals

### DIFF
--- a/zcash-insight-explorer/entrypoint.sh
+++ b/zcash-insight-explorer/entrypoint.sh
@@ -2,8 +2,8 @@
 
 set -eo pipefail
 
-if [[ ! -n ${ZCASHD_NETWORK} ]];then
-  echo "ZCASHD_NETWORK must be set"
+if [[ ! -n ${ZCASHD_NETWORK} ]] && [[ ! -n ${ZCASHD_RPC_PORT} ]];then
+  echo "ZCASHD_NETWORK or ZCASHD_RPC_PORT must be set"
   exit 1
 fi
 if [[ ! -n ${ZCASHD_RPCUSER} ]];then
@@ -19,19 +19,20 @@ if [[ ! -n ${ZCASHD_ZMQPORT} ]];then
   exit 1
 fi
 
-case ${ZCASHD_NETWORK} in
-  testnet)
-    export ZCASHD_RPC_PORT=18232
-    ;;
-  mainnet)
-    export ZCASHD_RPC_PORT=8232
-    ;;
-  *)
-    echo "Error, unknown network: ${ZCASHD_NETWORK}"
-    exit 1
-    ;;
-esac
-
+if [[ ! -n ${ZCASHD_RPC_PORT} ]];then
+  case ${ZCASHD_NETWORK} in
+    testnet)
+      export ZCASHD_RPC_PORT=18232
+      ;;
+    mainnet)
+      export ZCASHD_RPC_PORT=8232
+      ;;
+    *)
+      echo "Error, unknown network: ${ZCASHD_NETWORK}"
+      exit 1
+      ;;
+  esac
+fi
 env | sort
 
 envsubst < bitcore-node.json.template > zc/bitcore-node.json
@@ -42,4 +43,4 @@ if [[ $ZCASHD_NETWORK == 'testnet' ]];then
   sed -i 's/testnet = false/testnet = true/g' node_modules/insight-ui-zcash/public/src/js/app.js
 fi
 
-node_modules/bitcore-node-zcash/bin/bitcore-node start
+eval exec node_modules/bitcore-node-zcash/bin/bitcore-node start


### PR DESCRIPTION
- allow the setting of the rpc port directly, instead of inferring from the network
- start nodejs with `exec eval` so it received signals (like to stop)

